### PR TITLE
Add slightly cursed workflow to update readme count

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,38 @@
+name: 'Update readme count'
+
+permissions:
+  contents: write
+
+on:
+  pull_request:
+    paths:
+      - 'arrays.py'
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          cp config.example.py config.py
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Get combination count
+        id: get-count
+        run: echo "count=$(python gen.py -c)" >> $GITHUB_OUTPUT
+      - name: Update readme
+        run:
+          python update_readme_count.py "${{ steps.get-count.outputs.count }}"
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: 'Add updated count to readme'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## What is?
 It's a silly fedi bot (currently at https://fox.nexus/@treats).
 
+### Possible combinations
+There are 88 folx and 156 treats, resulting in 13,728 possible combinations.
+
 ## Contributing
 ### Setting up
 ```bash

--- a/gen.py
+++ b/gen.py
@@ -29,7 +29,7 @@ def count_combinations() -> None:
     num_treats = len(TREATS)
     combinations = num_folx * num_treats
     print(
-        f"There are {num_folx} folx and {num_treats} treats, resulting in {combinations} possible combinations."
+        f"There are {num_folx} folx and {num_treats} treats, resulting in {combinations:,} possible combinations."
     )
 
 

--- a/update_readme_count.py
+++ b/update_readme_count.py
@@ -1,0 +1,21 @@
+import sys
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("No string given to update readme with")
+        sys.exit(1)
+
+    count_str = sys.argv[1]
+    print(f'Updating readme with "{count_str}"')
+
+    with open("README.md", "r") as readme:
+        lines = readme.readlines()
+
+    for index, line in enumerate(lines):
+        if "### Possible combinations" in line:
+            line_index = index + 1
+
+    lines[line_index] = count_str + "\n"
+
+    with open("README.md", "w") as readme:
+        readme.writelines(lines)


### PR DESCRIPTION
Closes #29

If a pull request edits `arrays.py`:
- Checkout the repo on the pull request's branch (as opposed to the default which checks out in detached HEAD state)
- Run `python gen.py -c` to count the possible combinations
- Update the specific line in the readme with the new counts
- Commit the readme change back to the PR using the `github_actions[bot]` account

Tested locally using `act` and in another fork – see an example of the PR being updated here: https://github.com/olivvybee/as-a-test/pull/3/commits