### PR TITLE
Give update-readme action permission to run checks

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,7 +1,8 @@
 name: 'Update readme count'
 
 permissions:
-  contents: write
+  contents: write # Permission to create commits
+  checks: write # Permission to trigger checks
 
 on:
   pull_request:


### PR DESCRIPTION
This *should* allow the bot's commits to trigger checks when it adds commits to PRs