### PR TITLE
Add logging to the script, as a treat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.py
 .vscode/
 last_*
 used_*
+*.log

--- a/gen.py
+++ b/gen.py
@@ -1,11 +1,14 @@
 import argparse
 import config
+import logging
 import os
 import random
 import sys
 from arrays import FOLX, TREATS
 from enum import Enum
 from mastodon import Mastodon
+
+log = logging.getLogger(__name__)
 
 # The chance for the treat to become a threat
 THREAT_PROBABILITY = 1 / 100
@@ -23,33 +26,55 @@ class Visibility(Enum):
         return self.value
 
 
+def get_log_level(no_log: bool, verbose: bool) -> int:
+    if no_log:
+        return logging.ERROR
+    elif verbose:
+        return logging.DEBUG
+    else:
+        return logging.INFO
+
+
 def count_combinations() -> None:
     """Calculate the number of possible outputs"""
     num_folx = len(FOLX)
     num_treats = len(TREATS)
     combinations = num_folx * num_treats
-    print(
-        f"There are {num_folx} folx and {num_treats} treats, resulting in {combinations:,} possible combinations."
-    )
+    output = f"There are {num_folx} folx and {num_treats} treats, resulting in {combinations:,} possible combinations."
+    log.info(output)
+    print(output)
 
 
 def write_status(
     status: str, dry_run: bool = False, visibility: Visibility = Visibility("unlisted")
 ) -> None:
     """Write a status to Mastodon"""
-    mastodon = Mastodon(access_token=config.ACCESS_TOKEN, api_base_url=config.API_URL)
     if dry_run is False:
         # Post
+        mastodon = Mastodon(
+            access_token=config.ACCESS_TOKEN, api_base_url=config.API_URL
+        )
         mastodon.status_post(status=status, visibility=str(visibility))
+        log.info('Posted "%s"', status)
         print(f"Posted {status}")
     else:
         print(f"Dry run, would have posted {status}")
+        log.info('Dry run, would have posted "%s"', status)
 
 
 def should_be_threat():
     """Use THREAT_PROBABILITY to determine if this treat should be a threat"""
     range_max = int(1 / THREAT_PROBABILITY)
-    return random.randint(1, range_max) == range_max
+    chosen_value = random.randint(1, range_max)
+    log.debug("Treat/Threat value %d (threat requires %d)", chosen_value, range_max)
+
+    is_threat = chosen_value == range_max
+    if is_threat:
+        log.debug("Post will be a threat")
+    else:
+        log.debug("Post will be a treat")
+
+    return is_threat
 
 
 def get_used_filename(thing: str) -> str:
@@ -79,6 +104,7 @@ def clear_used(thing: str) -> None:
     filename = get_used_filename(thing)
     with open(filename, "w") as f:
         f.write("")
+    log.info("Cleared used %s list", thing)
 
 
 if __name__ == "__main__":
@@ -104,7 +130,15 @@ if __name__ == "__main__":
         action="store",
         default="unlisted",
     )
+    parser.add_argument("--no-log", action="store_true", help="Disable logging")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose logging"
+    )
     args = parser.parse_args()
+
+    log_level = get_log_level(args.no_log, args.verbose)
+    log_format = "%(asctime)s %(levelname)-5s %(message)s"
+    logging.basicConfig(filename="as-a-treat.log", level=log_level, format=log_format)
 
     if args.count:
         count_combinations()
@@ -115,12 +149,14 @@ if __name__ == "__main__":
 
     # Remove previously used folx
     available_folx = [item for item in FOLX if item not in used_folx]
+    log.debug("%d unused folx remaining", len(available_folx))
     if len(available_folx) == 0:
         available_folx = FOLX
         clear_used("folx")
 
     # Remove previously used treats
     available_treats = [item for item in TREATS if item not in used_treats]
+    log.debug("%d unused treats remaining", len(available_treats))
     if len(available_treats) == 0:
         available_treats = TREATS
         clear_used("treats")
@@ -128,6 +164,7 @@ if __name__ == "__main__":
     # Choose a random folx and treat from the remaining available options
     folx = random.choice(available_folx)
     treat = random.choice(available_treats)
+    log.debug('Chose folx "%s" and treat "%s"', folx, treat)
 
     # Save the chosen folx and treat so they can't be picked again
     save_used("folx", folx)


### PR DESCRIPTION
Adds `info` and `debug` logging to the script, for debugging issues with generation. Only logs `info` by default, which can be disabled by passing `--no-log` or switched to `debug` by passing `--verbose`.

Example logs from testing:

```
2024-05-11 10:44:57,655 DEBUG 0 unused folx remaining
2024-05-11 10:44:57,655 INFO  Cleared used folx list
2024-05-11 10:44:57,655 DEBUG 221 unused treats remaining
2024-05-11 10:44:57,655 DEBUG Chose folx "Transfems" and treat "a ride on a Stadler KISS"
2024-05-11 10:44:57,656 DEBUG Treat/Threat value 17 (threat requires 100)
2024-05-11 10:44:57,656 DEBUG Post will be a treat
2024-05-11 10:44:57,656 INFO  Dry run, would have posted "Transfems can have a ride on a Stadler KISS, as a treat"
```