### PR TITLE
Update bio with counts

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ exclude =
     __pycache__,
     config.py
 max-line-length = 286
-ignore = W503, E722
+ignore = W503, E722, E231
 
 [isort]
 profile = black


### PR DESCRIPTION
Add `-u` / `--update-bio` which updates the bot's bio to

```
You can have another bot, as a treat.

I can choose from {count of folx} folx and {count of treats} treats, so there are {folx * treats} possible combinations.

I last updated this bio on {UTC datetime} (UTC).
```