### PR TITLE
Add IRC-flavored treats

### DIFF
--- a/arrays.py
+++ b/arrays.py
@@ -178,6 +178,9 @@ FOLX = [
     "donotsta.re users",
     "Cheese gobblers",
     "Disney adults",
+    "IRC users",
+    "ChanServ",
+    "NickServ",
 ]
 
 # The case of these will not be changed
@@ -553,4 +556,7 @@ TREATS = [
     "a 642 episode let's play series",
     "a 210 minute queue for a roller coaster",
     "double pepperoni",
+    "a quip",
+    "op",
+    "voice",
 ]


### PR DESCRIPTION
Might be worth changing “+o” to “mode +o” or something like that so it’s clearer (ditto +v), what do you think?

(Also, I have no idea why GitHub insisted on adding the Signed-off-by trailer… is that something you enabled for this repository or does it just do that now?)