### PR TITLE
The code can have improved JSON handling, as a treat

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -386,10 +386,18 @@ if __name__ == "__main__":
                 alt_wording = True
                 log.debug('Using alternate wording for treat: "%s"', treat_text)
         else:
-            log.error('Invalid JSON error - missing "text" attribute at arrays.py:%d. Treat in question: "%s"', where_treat, treat)
+            log.error(
+                'Invalid JSON error - missing "text" attribute at arrays.py:%d. Treat in question: "%s"',
+                where_treat,
+                treat,
+            )
             sys.exit(1)
     elif treat.startswith("{") and not treat.endswith("}"):
-        log.error('Malformed JSON error - unterminated JSON string at arrays.py:%d. Treat in question: "%s"', where_treat, treat)
+        log.error(
+            'Malformed JSON error - unterminated JSON string at arrays.py:%d. Treat in question: "%s"',
+            where_treat,
+            treat,
+        )
         sys.exit(1)
 
     log.debug('Picked folx "%s" and treat "%s"', folx, treat_text)

--- a/gen.py
+++ b/gen.py
@@ -364,21 +364,33 @@ if __name__ == "__main__":
     folx = random.choice(available_folx)
     treat = random.choice(available_treats)
 
-    # Handle 'alternate wording' treats
+    # fetch the chosen treat's line number for logging errors
+    with open("arrays.py") as treats_file:
+        for line_number, line in enumerate(treats_file, 1):
+            if treat in line:
+                where_treat = line_number
+
+    # default values for standard (non-json) treats
+    # they'll get updated below if required
+    alt_wording = False
+    treat_text = treat
+
+    # Handle cases of json treats
+    # if the json part isn't properly terminated, error out and exit
     if treat.startswith("{") and treat.endswith("}"):
-        if json.loads(treat).get("alt_wording") == "True" and "text" in json.loads(
-            treat
-        ):
-            alt_wording = True
+        # if text attribute exists, load its content and then check for alternate wording
+        # otherwise error out and exit
+        if "text" in json.loads(treat):
             treat_text = json.loads(treat)["text"]
-            log.debug('Using alternate wording for treat: "%s"', treat_text)
+            if json.loads(treat).get("alt_wording") == "True":
+                alt_wording = True
+                log.debug('Using alternate wording for treat: "%s"', treat_text)
         else:
-            # Something went wrong with the formatting
-            log.error("Treat formatting error - invalid JSON: %s", treat)
+            log.error('Invalid JSON error - missing "text" attribute at arrays.py:%d. Treat in question: "%s"', where_treat, treat)
             sys.exit(1)
-    else:
-        alt_wording = False
-        treat_text = treat
+    elif treat.startswith("{") and not treat.endswith("}"):
+        log.error('Malformed JSON error - unterminated JSON string at arrays.py:%d. Treat in question: "%s"', where_treat, treat)
+        sys.exit(1)
 
     log.debug('Picked folx "%s" and treat "%s"', folx, treat_text)
 


### PR DESCRIPTION
This PR is intended as a partial implementation/preparational (is that even a real word??) thingy for #333, but can be evaluated separately from that.

The code assumes from the get-go that the treat selected is a normal (i.e. non-JSON) treat. It first checks if the treat is in JSON, discarding it if it's malformed; after that, it fetches the text, erroring out if it's nonexistent; and only then it checks if alternate wording should be used. This means there's now two ways of displaying a treat with normal wording: once as usual, and the other through JSON with only the text attribute (i.e. like this: `{"text": "a cool example"}`). By the way, the code doesn't concern itself with the order of the attributes; however I don't know if that's also the case with the pre-rewrite code, as I haven't checked. The JSON-related error messages are now a little bit more specific, even including the error treat's line number, though that wasn't entirely my making (shout out the random stranger from StackOverflow whose answer I yoinked!)

Here's the output of tox:
```
flake8: OK ✔ in 0.84 seconds
black: OK ✔ in 1.09 seconds
isort: OK ✔ in 0.23 seconds
tests:
  flake8: OK (0.84=setup[0.10]+cmd[0.74] seconds)
  black: OK (1.09=setup[0.02]+cmd[1.07] seconds)
  isort: OK (0.23=setup[0.02]+cmd[0.21] seconds)
  test: OK (0.40=setup[0.02]+cmd[0.38] seconds)
  congratulations :) (2.61 seconds)
```
black had to of course complain about me doing oneliners, so that's what the second, much tinier commit is for. Yes, I should've probably run tox before I even committed the rewrite, but ah well, it happens. The fops has its moments of oopid sometimes :P

I've done some testing with a “specially crafted” arrays.py, of which the treats part is this
```python
TREATS = [
    "a normal treat",
    '{"text": "another normal treat"}',
    '{"alt_wording": "True", "text": "can receive an alternate treat"}',
    '{"text": "can receive a swapped alternate", "alt_wording": "True"}',
    '{"alt_wording": "True"} will get thrown a malformed alternate at their heads',
    'a JSON that goes {"alt_wording": "Gay"}',
    '{"alt_wording": "True"}', # this will error out
]
```
to just try a few scenarios and also intentionally trigger errors for testing purposes. The default arrays.py should be working, but please do shout at and feel free to bonk me if I fucked up anything due to my code.

And last but not least, awawa :3

Edit: typo FFUUUUU